### PR TITLE
Update ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ Configuration is mostly done inside the `Vagrantfile`. Key items are as follows:
 + `config.vm.provision` block and `puppet.facter` hash - contains details for Puppet, which will provision the VM. The `facter` hash is used for various details for WordPress and MySQL.
 
 ### How to Use
-To begin, copy `Vagrantfile.sample` to `Vagrantfile` and edit as needed. Optionally, install [Vagrant Hostsupdater](https://github.com/cogitatio/vagrant-hostsupdater) to automatically add the VM to your `hosts` file.
+To begin, copy `Vagrantfile.sample` to your machine in a folder where you want the website to be saved. Rename this file to `Vagrantfile` and edit line 16 as needed. Optionally, install [Vagrant Hostsupdater](https://github.com/cogitatio/vagrant-hostsupdater) to automatically add the VM to your `hosts` file.
 
-When complete, simply run `vagrant up` and if all goes well the environment should be ready to use in just a few minutes. phpMyAdmin will also be accessible at `/phpmyadmin`.
+You will also need to create a `www` folder and also copy the `puppet` folder and its contents in to the same folder you've copied, and edited, the `Vagrantfile` into,
+
+When all has been copied and edited; simply run `vagrant up` and, if all goes well, the environment should be ready to use in just a few minutes.
+
+phpMyAdmin will also be accessible at `/phpmyadmin`.
 
 The document root of the webserver is the `www` directory at the root of this project and is mapped to `/www` on the VM.
 


### PR DESCRIPTION
I use this quite a bit and used to trip up on the setup instructions so I've added the exact steps I do when I spin this up for a new website. Once the steps I've added have been done the 'vagrant up' command works perfectly. 

I find that without the folders added the command 'vagrant up' doesn't work as it's looking the puppet content and it fails to create/find a  'www' folder too.